### PR TITLE
Fix consistency file ontology naming

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -6,15 +6,6 @@ JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
 
 cd $DIR/..
 
-mvn -DskipTests install
-
-
-cd bpmn2stamp-converter/
-mvn compile
-mvn -DskipTests package
-mvn -DskipTests install
-
-cd ..
-
+mvn -DskipTests clean install
 cd bpmn2stamp-console/
 mvn assembly:single

--- a/bpmn2stamp-console/src/main/java/console/NoneTypeArgsProcessor.java
+++ b/bpmn2stamp-console/src/main/java/console/NoneTypeArgsProcessor.java
@@ -71,7 +71,7 @@ public class NoneTypeArgsProcessor implements ArgsProcessor<NoneTypeArgsProcesso
 			// OK one
 			String baseName = cmd.getOptionValue(outputFilesPrefixOpt);
 			outputBboFile = baseName + "-bbo.ttl";
-			outputStampFile = baseName + "-prestamp.ttl";
+			outputStampFile = baseName + "-pre-stamp.ttl";
 		}
 		String baseIri = cmd.getOptionValue(inputBaseIriOpt);
 		String bpmnFileArg = cmd.getOptionValue(inputBpmnFileNameOpt);

--- a/bpmn2stamp-converter/pom.xml
+++ b/bpmn2stamp-converter/pom.xml
@@ -227,7 +227,7 @@
                     </aspectLibraries>
                     <sources>
                         <source>
-                            <basedir>src/main/java/org/example/model</basedir>
+                            <basedir>${project.basedir}/src/main/java/org/example/model</basedir>
                             <includes>
                                 <include>**/stamp/model/*.java</include>
                                 <include>**/bbo/model/*.java</include>
@@ -250,7 +250,7 @@
                 <executions>
                     <execution>
                         <id>main</id>
-                        <phase>compile</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>compile</goal>
                             <!-- use this goal to weave all your main classes -->


### PR DESCRIPTION
We had:
`dozor-nad-provozovateli-letist-prestamp.ttl`

but 
`http://onto.fel.cvut.cz/ontologies/processes/ucl/dozor-nad-provozovateli-letist-pre-stamp`

Thus prestamp --> pre-stamp